### PR TITLE
IBX-1589: Renamed Extension ez_doctrine_schema to ibexa_doctrine_schema

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Symfony extension configuration definition for ez_doctrine_schema extension.
+ * Symfony's extension configuration definition for ibexa_doctrine_schema extension.
  */
 class Configuration implements ConfigurationInterface
 {
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('ez_doctrine_schema');
+        $treeBuilder = new TreeBuilder(DoctrineSchemaExtension::EXTENSION_NAME);
 
         $rootNode = $treeBuilder->getRootNode();
         $rootNode

--- a/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
+++ b/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
@@ -16,12 +16,14 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class DoctrineSchemaExtension extends Extension
 {
+    public const EXTENSION_NAME = 'ibexa_doctrine_schema';
+
     /**
      * Override default extension alias name to include Ibexa vendor in name.
      */
     public function getAlias(): string
     {
-        return 'ez_doctrine_schema';
+        return self::EXTENSION_NAME;
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

This PR renames Symfony Extension `ez_doctrine_schema` to `ibexa_doctrine_schema`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
