### PR TITLE
IBX-1817: Ensured that extra schema keys throw exception

### DIFF
--- a/src/lib/Importer/SchemaImporter.php
+++ b/src/lib/Importer/SchemaImporter.php
@@ -10,6 +10,7 @@ namespace Ibexa\DoctrineSchema\Importer;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Ibexa\Contracts\DoctrineSchema\Exception\InvalidConfigurationException;
 use Ibexa\Contracts\DoctrineSchema\SchemaImporterInterface as APISchemaImporter;
 use Symfony\Component\Yaml\Yaml;
 
@@ -70,6 +71,14 @@ class SchemaImporter implements APISchemaImporter
     ): void {
         $table = $schema->createTable($tableName);
 
+        $this->ensureNoExtraKeys($tableConfiguration, $tableName, [
+            'id',
+            'fields',
+            'foreignKeys',
+            'indexes',
+            'uniqueConstraints',
+        ]);
+
         if (isset($tableConfiguration['id'])) {
             $this->addSchemaTableColumns($table, $tableConfiguration['id']);
             $table->setPrimaryKey(array_keys($tableConfiguration['id']));
@@ -121,6 +130,15 @@ class SchemaImporter implements APISchemaImporter
     private function addSchemaTableColumns(Table $table, array $columnList): void
     {
         foreach ($columnList as $columnName => $columnConfiguration) {
+            $this->ensureNoExtraKeys($columnConfiguration, $table->getName(), [
+                'length',
+                'scale',
+                'precision',
+                'type',
+                'nullable',
+                'options',
+            ]);
+
             if (isset($columnConfiguration['length'])) {
                 $columnConfiguration['options']['length'] = $columnConfiguration['length'];
             }
@@ -142,6 +160,19 @@ class SchemaImporter implements APISchemaImporter
             if (isset($columnConfiguration['nullable'])) {
                 $column->setNotnull(!$columnConfiguration['nullable']);
             }
+        }
+    }
+
+    private function ensureNoExtraKeys(array $tableConfiguration, string $tableName, array $allowedKeys): void
+    {
+        $diff = array_diff(array_keys($tableConfiguration), $allowedKeys);
+        if (!empty($diff)) {
+            throw new InvalidConfigurationException(sprintf(
+                'Unhandled property in schema configuration for table "%s". "%s" keys are not allowed. Allowed keys: "%s".',
+                $tableName,
+                implode('", "', $diff),
+                implode('", "', $allowedKeys),
+            ));
         }
     }
 }

--- a/src/lib/Importer/SchemaImporter.php
+++ b/src/lib/Importer/SchemaImporter.php
@@ -130,7 +130,7 @@ class SchemaImporter implements APISchemaImporter
     private function addSchemaTableColumns(Table $table, array $columnList): void
     {
         foreach ($columnList as $columnName => $columnConfiguration) {
-            $this->ensureNoExtraKeys($columnConfiguration, $table->getName(), [
+            $this->ensureNoExtraKeys($columnConfiguration, $table->getName() . '.fields', [
                 'length',
                 'scale',
                 'precision',
@@ -163,13 +163,13 @@ class SchemaImporter implements APISchemaImporter
         }
     }
 
-    private function ensureNoExtraKeys(array $tableConfiguration, string $tableName, array $allowedKeys): void
+    private function ensureNoExtraKeys(array $tableConfiguration, string $location, array $allowedKeys): void
     {
         $diff = array_diff(array_keys($tableConfiguration), $allowedKeys);
         if (!empty($diff)) {
             throw new InvalidConfigurationException(sprintf(
-                'Unhandled property in schema configuration for table "%s". "%s" keys are not allowed. Allowed keys: "%s".',
-                $tableName,
+                'Unhandled property in schema configuration for "%s". "%s" keys are not allowed. Allowed keys: "%s".',
+                $location,
                 implode('", "', $diff),
                 implode('", "', $allowedKeys),
             ));

--- a/src/lib/Importer/SchemaImporter.php
+++ b/src/lib/Importer/SchemaImporter.php
@@ -130,7 +130,8 @@ class SchemaImporter implements APISchemaImporter
     private function addSchemaTableColumns(Table $table, array $columnList): void
     {
         foreach ($columnList as $columnName => $columnConfiguration) {
-            $this->ensureNoExtraKeys($columnConfiguration, $table->getName() . '.fields', [
+            $location = sprintf('%s.fields.%s', $table->getName(), $columnName);
+            $this->ensureNoExtraKeys($columnConfiguration, $location, [
                 'length',
                 'scale',
                 'precision',

--- a/tests/lib/Importer/SchemaImporterTest.php
+++ b/tests/lib/Importer/SchemaImporterTest.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
+use Ibexa\Contracts\DoctrineSchema\Exception\InvalidConfigurationException;
 use Ibexa\DoctrineSchema\Importer\SchemaImporter;
 use PHPUnit\Framework\TestCase;
 
@@ -217,6 +218,30 @@ class SchemaImporterTest extends TestCase
             $actualSchema,
             "Yaml schema definition {$yamlSchemaDefinitionFile} produced unexpected Schema object"
         );
+    }
+
+    public function testTableImportFailsIfUnhandledKeys(): void
+    {
+        $importer = new SchemaImporter();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Unhandled property in schema configuration for table "my_table". "foo" keys are not allowed. Allowed keys:'
+            . ' "id", "fields", "foreignKeys", "indexes", "uniqueConstraints".'
+        );
+        $importer->importFromFile(__DIR__ . '/_fixtures/failing-import.yaml');
+    }
+
+    public function testColumnImportFailsIfUnhandledKeys(): void
+    {
+        $importer = new SchemaImporter();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'Unhandled property in schema configuration for table "my_table". "bar" keys are not allowed. Allowed keys:'
+            . ' "length", "scale", "precision", "type", "nullable", "options".'
+        );
+        $importer->importFromFile(__DIR__ . '/_fixtures/failing-import-column.yaml');
     }
 }
 

--- a/tests/lib/Importer/SchemaImporterTest.php
+++ b/tests/lib/Importer/SchemaImporterTest.php
@@ -226,7 +226,7 @@ class SchemaImporterTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(
-            'Unhandled property in schema configuration for table "my_table". "foo" keys are not allowed. Allowed keys:'
+            'Unhandled property in schema configuration for "my_table". "foo" keys are not allowed. Allowed keys:'
             . ' "id", "fields", "foreignKeys", "indexes", "uniqueConstraints".'
         );
         $importer->importFromFile(__DIR__ . '/_fixtures/failing-import.yaml');
@@ -238,7 +238,7 @@ class SchemaImporterTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(
-            'Unhandled property in schema configuration for table "my_table". "bar" keys are not allowed. Allowed keys:'
+            'Unhandled property in schema configuration for "my_table.fields". "bar" keys are not allowed. Allowed keys:'
             . ' "length", "scale", "precision", "type", "nullable", "options".'
         );
         $importer->importFromFile(__DIR__ . '/_fixtures/failing-import-column.yaml');

--- a/tests/lib/Importer/SchemaImporterTest.php
+++ b/tests/lib/Importer/SchemaImporterTest.php
@@ -238,7 +238,7 @@ class SchemaImporterTest extends TestCase
 
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(
-            'Unhandled property in schema configuration for "my_table.fields". "bar" keys are not allowed. Allowed keys:'
+            'Unhandled property in schema configuration for "my_table.fields.foo". "bar" keys are not allowed. Allowed keys:'
             . ' "length", "scale", "precision", "type", "nullable", "options".'
         );
         $importer->importFromFile(__DIR__ . '/_fixtures/failing-import-column.yaml');

--- a/tests/lib/Importer/_fixtures/failing-import-column.yaml
+++ b/tests/lib/Importer/_fixtures/failing-import-column.yaml
@@ -1,0 +1,5 @@
+tables:
+    my_table:
+        fields:
+            foo:
+                bar: ~

--- a/tests/lib/Importer/_fixtures/failing-import.yaml
+++ b/tests/lib/Importer/_fixtures/failing-import.yaml
@@ -1,0 +1,3 @@
+tables:
+    my_table:
+        foo: bar


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1817](https://issues.ibexa.co/browse/IBX-1817)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | **yes - previously unhandled keys will throw exception**

This PR makes it so adding meaningless properties to schema will throw an exception. This is intended to safeguard against indices being placed erroneously in table "root". 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
