### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -8,7 +8,7 @@ services:
         public: false
     _instanceof:
         Ibexa\DoctrineSchema\Database\DbPlatform\DbPlatformInterface:
-            tags: ['doctrine.dbplatform']
+            tags: [ ibexa.doctrine.db.platform ]
 
     Ibexa\DoctrineSchema\Exporter\:
         resource: '../../../lib/Exporter/*'
@@ -18,7 +18,7 @@ services:
 
     Ibexa\DoctrineSchema\Database\DbPlatformFactory:
         arguments:
-            $dbPlatforms: !tagged doctrine.dbplatform
+            $dbPlatforms: !tagged ibexa.doctrine.db.platform
 
     Ibexa\DoctrineSchema\Database\DbPlatform\:
         resource: '../../../lib/Database/DbPlatform/*'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

This package contains only one internal tag rebranded as `ibexa.doctrine.db.platform`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
