### PR TITLE
Updated DumpSqlCommand to compare against existing database

### DIFF
--- a/src/bundle/Command/DumpSqlCommand.php
+++ b/src/bundle/Command/DumpSqlCommand.php
@@ -72,6 +72,16 @@ final class DumpSqlCommand extends Command
         }
 
         $io = new SymfonyStyle($input, $output);
+        $io->getErrorStyle()->caution(
+            [
+                'This operation should not be executed in a production environment!',
+                '',
+                'Use the incremental update to detect changes during development and use',
+                'the SQL DDL provided to manually update your database in production.',
+                '',
+            ]
+        );
+
         foreach ($sqls as $sql) {
             $io->writeln($sql . ';');
         }

--- a/src/bundle/Command/DumpSqlCommand.php
+++ b/src/bundle/Command/DumpSqlCommand.php
@@ -66,7 +66,6 @@ final class DumpSqlCommand extends Command
         return self::SUCCESS;
     }
 
-
     private function getSchemaManager(): AbstractSchemaManager
     {
         return $this->db->getSchemaManager();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR makes it so that schema comparison is executed against current database.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (`main` for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
