### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,17 @@ jobs:
         name: Run code style check
         runs-on: "ubuntu-22.04"
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: '8.1'
+                    php-version: '8.3'
                     coverage: none
                     extensions: pdo_sqlite, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 
@@ -38,12 +38,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -53,7 +51,7 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 
@@ -89,14 +87,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                experimental: [ false ]
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
+                    - '8.3'
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   name: Setup PHP Action
                 uses: shivammathur/setup-php@v2
@@ -106,7 +101,7 @@ jobs:
                     extensions: pdo_mysql, gd
                     tools: cs2pr
 
-            -   uses: ramsey/composer-install@v2
+            -   uses: ramsey/composer-install@v3
                 with:
                     dependency-versions: highest
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ezsystems/doctrine-dbal-schema": "*"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "doctrine/dbal": "^2.13",
         "symfony/config": "^5.3",
         "symfony/console": "^5.3",
@@ -17,10 +17,10 @@
     },
     "require-dev": {
         "ibexa/code-style": "^1.0",
-        "phpunit/phpunit": "^8.5",
         "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {
@@ -46,5 +46,8 @@
         "branch-alias": {
             "dev-main": "5.0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
