### PR TITLE
IBX-8139: Dropped class_alias BC layer statements from all classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
         "psr-4": {
             "Ibexa\\DoctrineSchema\\": "src/lib/",
             "Ibexa\\Bundle\\DoctrineSchema\\": "src/bundle/",
-            "Ibexa\\Contracts\\DoctrineSchema\\": "src/contracts/",
-            "EzSystems\\DoctrineSchemaBundle\\": "src/bundle",
-            "EzSystems\\DoctrineSchema\\": "src/lib"
+            "Ibexa\\Contracts\\DoctrineSchema\\": "src/contracts/"
         }
     },
     "autoload-dev": {

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -40,5 +40,3 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 }
-
-class_alias(Configuration::class, 'EzSystems\DoctrineSchemaBundle\DependencyInjection\Configuration');

--- a/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
+++ b/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
@@ -55,5 +55,3 @@ class DoctrineSchemaExtension extends Extension
         }
     }
 }
-
-class_alias(DoctrineSchemaExtension::class, 'EzSystems\DoctrineSchemaBundle\DependencyInjection\DoctrineSchemaExtension');

--- a/src/bundle/DoctrineSchemaBundle.php
+++ b/src/bundle/DoctrineSchemaBundle.php
@@ -22,5 +22,3 @@ class DoctrineSchemaBundle extends Bundle
         return new DoctrineSchemaExtension();
     }
 }
-
-class_alias(DoctrineSchemaBundle::class, 'EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle');

--- a/src/contracts/Builder/SchemaBuilderInterface.php
+++ b/src/contracts/Builder/SchemaBuilderInterface.php
@@ -31,5 +31,3 @@ interface SchemaBuilderInterface
      */
     public function importSchemaFromFile(string $schemaFilePath): Schema;
 }
-
-class_alias(SchemaBuilderInterface::class, 'EzSystems\DoctrineSchema\API\Builder\SchemaBuilder');

--- a/src/contracts/DbPlatformFactoryInterface.php
+++ b/src/contracts/DbPlatformFactoryInterface.php
@@ -26,5 +26,3 @@ interface DbPlatformFactoryInterface
      */
     public function createDatabasePlatformFromDriverName(string $driverName): ?AbstractPlatform;
 }
-
-class_alias(DbPlatformFactoryInterface::class, 'EzSystems\DoctrineSchema\API\DbPlatformFactory');

--- a/src/contracts/Event/SchemaBuilderEvent.php
+++ b/src/contracts/Event/SchemaBuilderEvent.php
@@ -38,5 +38,3 @@ class SchemaBuilderEvent extends Event
         return $this->schemaBuilder;
     }
 }
-
-class_alias(SchemaBuilderEvent::class, 'EzSystems\DoctrineSchema\API\Event\SchemaBuilderEvent');

--- a/src/contracts/Exception/InvalidConfigurationException.php
+++ b/src/contracts/Exception/InvalidConfigurationException.php
@@ -18,5 +18,3 @@ class InvalidConfigurationException extends Exception
         parent::__construct("Invalid schema configuration: {$message}", $code, $previous);
     }
 }
-
-class_alias(InvalidConfigurationException::class, 'EzSystems\DoctrineSchema\API\Exception\InvalidConfigurationException');

--- a/src/contracts/SchemaBuilderEvents.php
+++ b/src/contracts/SchemaBuilderEvents.php
@@ -12,5 +12,3 @@ class SchemaBuilderEvents
 {
     public const BUILD_SCHEMA = 'ibexa.schema.build_schema';
 }
-
-class_alias(SchemaBuilderEvents::class, 'EzSystems\DoctrineSchema\API\Event\SchemaBuilderEvents');

--- a/src/contracts/SchemaExporterInterface.php
+++ b/src/contracts/SchemaExporterInterface.php
@@ -20,5 +20,3 @@ interface SchemaExporterInterface
      */
     public function export(Schema $schemaDefinition): string;
 }
-
-class_alias(SchemaExporterInterface::class, 'EzSystems\DoctrineSchema\API\SchemaExporter');

--- a/src/contracts/SchemaImporterInterface.php
+++ b/src/contracts/SchemaImporterInterface.php
@@ -41,5 +41,3 @@ interface SchemaImporterInterface
      */
     public function importFromSource(string $schemaDefinition, ?Schema $targetSchema = null): Schema;
 }
-
-class_alias(SchemaImporterInterface::class, 'EzSystems\DoctrineSchema\API\SchemaImporter');

--- a/src/lib/Builder/SchemaBuilder.php
+++ b/src/lib/Builder/SchemaBuilder.php
@@ -74,5 +74,3 @@ class SchemaBuilder implements APISchemaBuilder
         return $this->schemaImporter->importFromFile($schemaFilePath, $this->schema);
     }
 }
-
-class_alias(SchemaBuilder::class, 'EzSystems\DoctrineSchema\Builder\SchemaBuilder');

--- a/src/lib/Database/DbPlatform/DbPlatformInterface.php
+++ b/src/lib/Database/DbPlatform/DbPlatformInterface.php
@@ -27,5 +27,3 @@ interface DbPlatformInterface
      */
     public function addEventSubscribers(EventManager $eventManager): void;
 }
-
-class_alias(DbPlatformInterface::class, 'EzSystems\DoctrineSchema\Database\DbPlatform\DbPlatform');

--- a/src/lib/Database/DbPlatform/PostgreSqlDbPlatform.php
+++ b/src/lib/Database/DbPlatform/PostgreSqlDbPlatform.php
@@ -72,5 +72,3 @@ class PostgreSqlDbPlatform extends PostgreSQL100Platform implements DbPlatformIn
         return 'DROP TABLE IF EXISTS ' . $table . ' CASCADE';
     }
 }
-
-class_alias(PostgreSqlDbPlatform::class, 'EzSystems\DoctrineSchema\Database\DbPlatform\PostgreSqlDbPlatform');

--- a/src/lib/Database/DbPlatform/SqliteDbPlatform.php
+++ b/src/lib/Database/DbPlatform/SqliteDbPlatform.php
@@ -81,5 +81,3 @@ class SqliteDbPlatform extends SqlitePlatform implements DbPlatformInterface
         return '-- ';
     }
 }
-
-class_alias(SqliteDbPlatform::class, 'EzSystems\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform');

--- a/src/lib/Database/DbPlatformFactory.php
+++ b/src/lib/Database/DbPlatformFactory.php
@@ -34,5 +34,3 @@ class DbPlatformFactory implements APIDbPlatformFactory
         return $this->dbPlatforms[$driverName] ?? null;
     }
 }
-
-class_alias(DbPlatformFactory::class, 'EzSystems\DoctrineSchema\Database\DbPlatformFactory');

--- a/src/lib/Exporter/SchemaExporter.php
+++ b/src/lib/Exporter/SchemaExporter.php
@@ -48,5 +48,3 @@ class SchemaExporter implements APISchemaExporter
         return Yaml::dump($schemaDefinition, 4);
     }
 }
-
-class_alias(SchemaExporter::class, 'EzSystems\DoctrineSchema\Exporter\SchemaExporter');

--- a/src/lib/Exporter/Table/SchemaTableExporter.php
+++ b/src/lib/Exporter/Table/SchemaTableExporter.php
@@ -151,5 +151,3 @@ class SchemaTableExporter
         return $tableMetadata;
     }
 }
-
-class_alias(SchemaTableExporter::class, 'EzSystems\DoctrineSchema\Exporter\Table\SchemaTableExporter');

--- a/src/lib/Importer/SchemaImporter.php
+++ b/src/lib/Importer/SchemaImporter.php
@@ -271,5 +271,3 @@ class SchemaImporter implements APISchemaImporter
         return $indexConfig;
     }
 }
-
-class_alias(SchemaImporter::class, 'EzSystems\DoctrineSchema\Importer\SchemaImporter');

--- a/tests/lib/Builder/SchemaBuilderTest.php
+++ b/tests/lib/Builder/SchemaBuilderTest.php
@@ -52,5 +52,3 @@ class SchemaBuilderTest extends TestCase
         );
     }
 }
-
-class_alias(SchemaBuilderTest::class, 'EzSystems\Tests\DoctrineSchema\Builder\SchemaBuilderTest');

--- a/tests/lib/Database/Builder/MySqlTestDatabaseBuilder.php
+++ b/tests/lib/Database/Builder/MySqlTestDatabaseBuilder.php
@@ -42,5 +42,3 @@ class MySqlTestDatabaseBuilder implements TestDatabaseBuilder
         return $connection;
     }
 }
-
-class_alias(MySqlTestDatabaseBuilder::class, 'EzSystems\Tests\DoctrineSchema\Database\Builder\MySqlTestDatabaseBuilder');

--- a/tests/lib/Database/Builder/SqliteTestDatabaseBuilder.php
+++ b/tests/lib/Database/Builder/SqliteTestDatabaseBuilder.php
@@ -35,5 +35,3 @@ class SqliteTestDatabaseBuilder implements TestDatabaseBuilder
         );
     }
 }
-
-class_alias(SqliteTestDatabaseBuilder::class, 'EzSystems\Tests\DoctrineSchema\Database\Builder\SqliteTestDatabaseBuilder');

--- a/tests/lib/Database/Builder/TestDatabaseBuilder.php
+++ b/tests/lib/Database/Builder/TestDatabaseBuilder.php
@@ -18,5 +18,3 @@ interface TestDatabaseBuilder
      */
     public function buildDatabase(): Connection;
 }
-
-class_alias(TestDatabaseBuilder::class, 'EzSystems\Tests\DoctrineSchema\Database\Builder\TestDatabaseBuilder');

--- a/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
+++ b/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
@@ -60,5 +60,3 @@ class SqliteDbPlatformTest extends TestCase
         $connection->insert($secondaryTable->getName(), ['id' => 2], [ParameterType::INTEGER]);
     }
 }
-
-class_alias(SqliteDbPlatformTest::class, 'EzSystems\Tests\DoctrineSchema\Database\DbPlatform\SqliteDbPlatformTest');

--- a/tests/lib/Database/TestDatabaseConfigurationException.php
+++ b/tests/lib/Database/TestDatabaseConfigurationException.php
@@ -11,5 +11,3 @@ namespace Ibexa\Tests\DoctrineSchema\Database;
 class TestDatabaseConfigurationException extends \Exception
 {
 }
-
-class_alias(TestDatabaseConfigurationException::class, 'EzSystems\Tests\DoctrineSchema\Database\TestDatabaseConfigurationException');

--- a/tests/lib/Database/TestDatabaseFactory.php
+++ b/tests/lib/Database/TestDatabaseFactory.php
@@ -38,5 +38,3 @@ class TestDatabaseFactory
         return $this->databaseBuildersForPlatforms[$name]->buildDatabase();
     }
 }
-
-class_alias(TestDatabaseFactory::class, 'EzSystems\Tests\DoctrineSchema\Database\TestDatabaseFactory');

--- a/tests/lib/Exporter/SchemaExporterTest.php
+++ b/tests/lib/Exporter/SchemaExporterTest.php
@@ -135,5 +135,3 @@ class SchemaExporterTest extends TestCase
         return $this->testDatabaseFactory->prepareAndConnect($databasePlatform);
     }
 }
-
-class_alias(SchemaExporterTest::class, 'EzSystems\Tests\DoctrineSchema\Exporter\SchemaExporterTest');


### PR DESCRIPTION
| :ticket: Issue | IBX-8139 |
|----------------|-----------|

#### Description:

Dropped `ez_class` BC layer statements from all classes using https://github.com/ibexa/rector/pull/2

#### For QA:

No QA needed

#### Documentation:

Document that our BC layer has been dropped
