### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method Ibexa\\Bundle\\DoctrineSchema\\DependencyInjection\\DoctrineSchemaExtension\:\:load\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/DoctrineSchemaExtension.php
-
-		-
 			message: '#^Method Ibexa\\DoctrineSchema\\Builder\\SchemaBuilder\:\:__construct\(\) has parameter \$defaultTableOptions with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -133,25 +127,7 @@ parameters:
 			path: src/lib/Importer/SchemaImporter.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\DoctrineSchema\\Builder\\SchemaBuilderTest\:\:testBuildSchema\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Builder/SchemaBuilderTest.php
-
-		-
-			message: '#^Method Symfony\\Component\\EventDispatcher\\EventSubscriberInterface@anonymous/tests/lib/Builder/SchemaBuilderTest\.php\:33\:\:onBuildSchema\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Builder/SchemaBuilderTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\DoctrineSchema\\Exporter\\SchemaExporterTest\:\:providerForTestExport\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Exporter/SchemaExporterTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\DoctrineSchema\\Importer\\SchemaImporterTest\:\:testImportFromFile\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Importer/SchemaImporterTest.php

--- a/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
+++ b/src/bundle/DependencyInjection/DoctrineSchemaExtension.php
@@ -31,7 +31,7 @@ class DoctrineSchemaExtension extends Extension
      *
      * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,

--- a/src/contracts/Event/SchemaBuilderEvent.php
+++ b/src/contracts/Event/SchemaBuilderEvent.php
@@ -14,13 +14,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class SchemaBuilderEvent extends Event
 {
-    /** @var \Ibexa\Contracts\DoctrineSchema\Builder\SchemaBuilderInterface */
-    private $schemaBuilder;
+    private SchemaBuilderInterface $schemaBuilder;
 
-    /**
-     * @var \Doctrine\DBAL\Schema\Schema
-     */
-    private $schema;
+    private Schema $schema;
 
     public function __construct(SchemaBuilderInterface $schemaBuilder, Schema $schema)
     {

--- a/src/lib/Builder/SchemaBuilder.php
+++ b/src/lib/Builder/SchemaBuilder.php
@@ -25,25 +25,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class SchemaBuilder implements APISchemaBuilder
 {
-    /**
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
-     */
-    private $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
 
-    /**
-     * @var \Ibexa\Contracts\DoctrineSchema\SchemaImporterInterface
-     */
-    private $schemaImporter;
+    private SchemaImporterInterface $schemaImporter;
 
-    /**
-     * @var \Doctrine\DBAL\Schema\Schema
-     */
-    private $schema;
+    private ?Schema $schema = null;
 
-    /**
-     * @var array
-     */
-    private $defaultTableOptions;
+    private array $defaultTableOptions;
 
     public function __construct(
         EventDispatcherInterface $eventDispatcher,

--- a/src/lib/Exporter/SchemaExporter.php
+++ b/src/lib/Exporter/SchemaExporter.php
@@ -20,8 +20,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class SchemaExporter implements APISchemaExporter
 {
-    /** @var \Ibexa\DoctrineSchema\Exporter\Table\SchemaTableExporter */
-    private $tableExporter;
+    private SchemaTableExporter $tableExporter;
 
     public function __construct(SchemaTableExporter $tableYamlExporter)
     {

--- a/tests/lib/Builder/SchemaBuilderTest.php
+++ b/tests/lib/Builder/SchemaBuilderTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SchemaBuilderTest extends TestCase
 {
-    public function testBuildSchema()
+    public function testBuildSchema(): void
     {
         $eventDispatcher = new EventDispatcher();
 
@@ -38,7 +38,7 @@ class SchemaBuilderTest extends TestCase
                     ];
                 }
 
-                public function onBuildSchema(SchemaBuilderEvent $event)
+                public function onBuildSchema(SchemaBuilderEvent $event): void
                 {
                     $event
                         ->getSchema()->createTable('my_table');

--- a/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
+++ b/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
@@ -17,10 +17,10 @@ use PHPUnit\Framework\TestCase;
 class SqliteDbPlatformTest extends TestCase
 {
     /** @var \Ibexa\Tests\DoctrineSchema\Database\TestDatabaseFactory */
-    private $testDatabaseFactory;
+    private TestDatabaseFactory $testDatabaseFactory;
 
     /** @var \Ibexa\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform */
-    private $sqliteDbPlatform;
+    private SqliteDbPlatform $sqliteDbPlatform;
 
     public function setUp(): void
     {

--- a/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
+++ b/tests/lib/Database/DbPlatform/SqliteDbPlatformTest.php
@@ -16,10 +16,8 @@ use PHPUnit\Framework\TestCase;
 
 class SqliteDbPlatformTest extends TestCase
 {
-    /** @var \Ibexa\Tests\DoctrineSchema\Database\TestDatabaseFactory */
     private TestDatabaseFactory $testDatabaseFactory;
 
-    /** @var \Ibexa\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform */
     private SqliteDbPlatform $sqliteDbPlatform;
 
     public function setUp(): void

--- a/tests/lib/Database/TestDatabaseFactory.php
+++ b/tests/lib/Database/TestDatabaseFactory.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 class TestDatabaseFactory
 {
     /** @var \Ibexa\Tests\DoctrineSchema\Database\Builder\TestDatabaseBuilder[] */
-    private $databaseBuildersForPlatforms = [];
+    private array $databaseBuildersForPlatforms = [];
 
     public function __construct()
     {

--- a/tests/lib/Exporter/SchemaExporterTest.php
+++ b/tests/lib/Exporter/SchemaExporterTest.php
@@ -21,10 +21,10 @@ use PHPUnit\Framework\TestCase;
 class SchemaExporterTest extends TestCase
 {
     /** @var \Ibexa\DoctrineSchema\Exporter\SchemaExporter */
-    private $exporter;
+    private SchemaExporter $exporter;
 
     /** @var \Ibexa\Tests\DoctrineSchema\Database\TestDatabaseFactory */
-    private $testDatabaseFactory;
+    private TestDatabaseFactory $testDatabaseFactory;
 
     public function setUp(): void
     {

--- a/tests/lib/Exporter/SchemaExporterTest.php
+++ b/tests/lib/Exporter/SchemaExporterTest.php
@@ -20,10 +20,8 @@ use PHPUnit\Framework\TestCase;
 
 class SchemaExporterTest extends TestCase
 {
-    /** @var \Ibexa\DoctrineSchema\Exporter\SchemaExporter */
     private SchemaExporter $exporter;
 
-    /** @var \Ibexa\Tests\DoctrineSchema\Database\TestDatabaseFactory */
     private TestDatabaseFactory $testDatabaseFactory;
 
     public function setUp(): void

--- a/tests/lib/Importer/SchemaImporterTest.php
+++ b/tests/lib/Importer/SchemaImporterTest.php
@@ -286,7 +286,7 @@ class SchemaImporterTest extends TestCase
     public function testImportFromFile(
         string $yamlSchemaDefinitionFile,
         Schema $expectedSchema
-    ) {
+    ): void {
         $yamlSchemaDefinitionFilePath = realpath(__DIR__ . "/_fixtures/{$yamlSchemaDefinitionFile}");
         if (false === $yamlSchemaDefinitionFilePath) {
             self::markTestIncomplete("Missing output fixture {$yamlSchemaDefinitionFilePath}");


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
