### PR TITLE
Updated services.yaml to replace deprecated `!tagged` with `!tagged_iterator`

### DIFF
--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -18,7 +18,7 @@ services:
 
     Ibexa\DoctrineSchema\Database\DbPlatformFactory:
         arguments:
-            $dbPlatforms: !tagged ibexa.doctrine.db.platform
+            $dbPlatforms: !tagged_iterator ibexa.doctrine.db.platform
 
     Ibexa\DoctrineSchema\Database\DbPlatform\:
         resource: '../../../lib/Database/DbPlatform/*'


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
Replaced the deprecated `!tagged` syntax with `!tagged_iterator` in `doctrine-schema` bundle's service definition for `DbPlatformFactory`.

This update follows Symfony 7.2 best practices and removes the deprecation warning:

> Using "!tagged" is deprecated, use "!tagged_iterator" instead

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
