### PR TITLE
IBX-10228: Bump symfony/* requirement to ^7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "require": {
         "php": " >=8.3",
         "doctrine/dbal": "^3.7.0",
-        "symfony/config": "^7.2",
-        "symfony/console": "^7.2",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/yaml": "^7.2"
+        "symfony/config": "^7.3",
+        "symfony/console": "^7.3",
+        "symfony/dependency-injection": "^7.3",
+        "symfony/http-kernel": "^7.3",
+        "symfony/yaml": "^7.3"
     },
     "require-dev": {
         "ibexa/code-style": "~2.0.0",


### PR DESCRIPTION
| :ticket: Issue | IBX-10228    |
|----------------|--------------|

#### Description:
This PR updates all symfony/* dependencies to ^7.3.

#### For QA:
N/A

#### Documentation:
N/A

