### PR TITLE
IBX-10507: Allowed nullable type declarations for method parameters across the codebase 

### DIFF
--- a/src/contracts/Exception/InvalidConfigurationException.php
+++ b/src/contracts/Exception/InvalidConfigurationException.php
@@ -13,7 +13,7 @@ use Throwable;
 
 class InvalidConfigurationException extends Exception
 {
-    public function __construct(string $message = '', int $code = 1, Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 1, ?Throwable $previous = null)
     {
         parent::__construct("Invalid schema configuration: {$message}", $code, $previous);
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-10507 |
|----------------|-----------|

#### Description:
Allowed nullable type declarations for method parameters across the codebase
