### PR TITLE
Fixed charset on SQL dump from YAML schema

### DIFF
--- a/src/lib/Builder/SchemaBuilder.php
+++ b/src/lib/Builder/SchemaBuilder.php
@@ -70,6 +70,15 @@ class SchemaBuilder implements APISchemaBuilder
      */
     public function importSchemaFromFile(string $schemaFilePath): Schema
     {
-        return $this->schemaImporter->importFromFile($schemaFilePath, $this->schema);
+        $schema = $this->schemaImporter->importFromFile($schemaFilePath, $this->schema);
+        foreach ($schema->getTables() as $table) {
+            foreach ($this->defaultTableOptions as $option => $value) {
+                if (!$table->hasOption($option)) {
+                    $table->addOption($option, $value);
+                }
+            }
+        }
+
+        return $schema;
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Inject the default table options into the schema imported from file.

It avoids having `` DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` `` from https://github.com/doctrine/dbal/blob/3.10.x/src/Platforms/AbstractMySQLPlatform.php#L579-L600 when using `ibexa:doctrine:schema:dump-sql` on files like https://github.com/ibexa/oauth2-server/blob/main/src/bundle/Resources/config/schema.yaml or https://github.com/ibexa/shopping-list/blob/main/src/bundle/Resources/config/schema.yaml

Notice that it might disappear by itself if we move to doctrine/dbal 4 as there is no hardcoded charset in https://github.com/doctrine/dbal/blob/4.4.x/src/Platforms/AbstractMySQLPlatform.php#L331-L337

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
